### PR TITLE
add line 77 for preventing video size gets changed when the video gets double tapped

### DIFF
--- a/VideoSplash/Source/VideoSplashViewController.swift
+++ b/VideoSplash/Source/VideoSplashViewController.swift
@@ -74,6 +74,7 @@ public class VideoSplashViewController: UIViewController {
   override public func viewDidAppear(animated: Bool) {
     moviePlayer.view.frame = videoFrame
     moviePlayer.showsPlaybackControls = false
+    moviePlayer.view.userInteractionEnabled = false
     view.addSubview(moviePlayer.view)
     view.sendSubviewToBack(moviePlayer.view)
   }


### PR DESCRIPTION
When a user double tapped the video, the video size returns to AspectFit. It interrupts the consistency of the video. Adding my change can solve the problem, although I am not sure this is the best solution for it.
