### PR TITLE
Background color glitch

### DIFF
--- a/VideoSplashKit/Source/VideoSplashViewController.swift
+++ b/VideoSplashKit/Source/VideoSplashViewController.swift
@@ -84,6 +84,7 @@ public class VideoSplashViewController: UIViewController {
 
   override public func viewDidAppear(animated: Bool) {
     moviePlayer.view.frame = videoFrame
+    moviePlayer.view.backgroundColor = self.backgroundColor;
     moviePlayer.showsPlaybackControls = false
     moviePlayer.view.userInteractionEnabled = false
     view.addSubview(moviePlayer.view)


### PR DESCRIPTION
The movie player was covering the entire frame with a black background so even if you set a background color it wouldn't show and you would see a black flicker before the video started playing. Fixed the issue by setting the movie player background color on viewDidAppear.
