### PR TITLE
Excluded output.mp4 from iCloud backup

### DIFF
--- a/VideoSplashKit/Source/VideoCutter.swift
+++ b/VideoSplashKit/Source/VideoCutter.swift
@@ -68,6 +68,10 @@ public class VideoCutter: NSObject {
         }
       }
       dispatch_async(dispatch_get_main_queue()) {
+        do {
+            try NSURL(fileURLWithPath: outputURL!).setResourceValue(true, forKey: NSURLIsExcludedFromBackupKey)
+        } catch _{
+        }
       }
     }
   }


### PR DESCRIPTION
Excluded output from iCloud backup, to be in agreement with iOS Data Storage Guidelines
